### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/backend/routes/scrobbleSong.js
+++ b/backend/routes/scrobbleSong.js
@@ -81,7 +81,17 @@ router.post('/', async (req, res) => {
     // Add 'format=json' ONLY to the request, NOT in the signature
     params['format'] = 'json';
 
-    console.log('Corrected Request parameters:', params);
+    // Log only non-sensitive parameters for debugging
+    const safeParams = {
+        method: params.method,
+        artist: params.artist,
+        track: params.track,
+        album: album,
+        timestamp: params.timestamp,
+        chosenByUser: params.chosenByUser,
+        format: params.format
+    };
+    console.log('Corrected Request parameters (safe):', safeParams);
 
     try {
         const response = await axios.post('https://ws.audioscrobbler.com/2.0/', 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/Scrozam/security/code-scanning/13](https://github.com/djleamen/Scrozam/security/code-scanning/13)

To fix the problem, we should avoid logging sensitive information such as API keys, session keys, and API signatures. Instead, we can log only non-sensitive parameters (e.g., artist, title, album, timestamp, chosenByUser) for debugging purposes. The fix involves modifying the log statement on line 84 to exclude sensitive fields from the logged object. This can be done by creating a new object that contains only the non-sensitive fields and logging that instead. No new imports are required, and the change is limited to the log statement on line 84 in `backend/routes/scrobbleSong.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
