### PR TITLE
Potential fix for code scanning alert no. 26: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -15,12 +15,19 @@ require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3001';
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 // ─── CORS (must come before session + routes) ─────────────────────────────────
 app.use(cors({
     origin: FRONTEND_URL,
     credentials: true,      // allow cookies
 }));
+
+// If running behind a reverse proxy (e.g. Heroku, Render, nginx), let Express
+// know so that secure cookies work correctly when TLS is terminated upstream.
+if (IS_PRODUCTION) {
+    app.set('trust proxy', 1);
+}
 
 // ─── Session ──────────────────────────────────────────────────────────────────
 app.use(session({
@@ -29,7 +36,7 @@ app.use(session({
     saveUninitialized: false,
     cookie: {
         httpOnly: true,
-        secure: false,          // set true in production with HTTPS
+        secure: IS_PRODUCTION,   // enforce HTTPS-only cookies in production
         sameSite: 'lax',
         maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
     },


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/Scrozam/security/code-scanning/26](https://github.com/djleamen/Scrozam/security/code-scanning/26)

In general, the fix is to ensure that the session cookie is only sent over HTTPS by setting `cookie.secure: true` for real deployments, while still allowing `secure: false` in local development over plain HTTP. This is commonly done by tying the `secure` flag to `NODE_ENV` and/or an explicit configuration variable, and ensuring Express trusts the reverse proxy if TLS is terminated in front of Node.

The best way to fix this snippet without changing existing functionality is:
- Introduce a simple runtime check (e.g. `const isProduction = process.env.NODE_ENV === 'production';`).
- Use that check to set `cookie.secure` to `true` when in production, and keep it `false` during development so cookies still work on `http://localhost`.
- Optionally (and safely) add `app.set('trust proxy', 1);` when running behind a proxy that handles HTTPS, so that `secure` cookies are correctly handled even though Node itself only sees HTTP.

Concretely in `backend/app.js`:
- Above the session middleware, compute a boolean to indicate whether secure cookies should be used.
- Replace `secure: false` with that boolean, and update the comment to reflect the new behavior.
- Optionally, add `app.set('trust proxy', 1);` right before setting up the session if you expect production deployments behind a reverse proxy (this does not affect local dev unless a proxy is in use).

No new external libraries are needed; this can be achieved with environment variables already available via `dotenv`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
