### PR TITLE
Potential fix for code scanning alert no. 27: Server-side request forgery

### DIFF
--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -207,8 +207,10 @@ router.get('/proxy', async (req, res) => {
     return res.status(400).send('URL not allowed');
   }
 
+  const safeUrl = parsedUrl.toString();
+
   try {
-    const imageRes = await axios.get(url, {
+    const imageRes = await axios.get(safeUrl, {
       responseType: 'stream',
       headers: {
         'Referer': 'https://www.last.fm/',


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/Scrozam/security/code-scanning/27](https://github.com/djleamen/Scrozam/security/code-scanning/27)

In general, to fix SSRF issues you must ensure that the URL you pass to the HTTP client is derived from a validated, constrained representation of user input, not from the raw string the user supplied. Hostnames and protocols should be checked against allow‑lists, and any parts of the URL that are not needed (such as username, password, or arbitrary ports) should be disallowed or normalized.

For this specific route, the best targeted fix is to (1) continue parsing and validating `url` with `new URL(url)`, (2) keep the existing protocol and hostname allow‑list checks, but (3) build a sanitized URL string from the `parsedUrl` object and pass that sanitized string to `axios.get` instead of the original `url`. While rebuilding, we should explicitly use `parsedUrl.protocol`, `hostname`, `port` (only if we want to allow non‑default ports), and `pathname + search` + `hash`, and ignore any credentials (`username`, `password`) entirely. To keep functionality unchanged but safer, we can reconstruct the URL using `parsedUrl.toString()` (which is derived from the already parsed object) or manually build it; both remove any influence of odd raw string encodings that might have slipped through. The minimal change inside `backend/routes/albumArt.js` is:

- After validating `parsedUrl`, create `const safeUrl = parsedUrl.toString();`.
- Use `safeUrl` instead of `url` in `axios.get(...)`.

All changes are confined to `backend/routes/albumArt.js`, within the existing `/proxy` route, and no new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
