### PR TITLE
fix: harden detection polling and ACRCloud response handling

### DIFF
--- a/backend/routes/detectSong.js
+++ b/backend/routes/detectSong.js
@@ -81,7 +81,9 @@ router.post('/', upload.single('sample'), async (req, res) => {
     });
 
     if (response.data.status.code === 0) {
-      const musicData = response.data.metadata.music[0];
+      // Guard the whole chain: a success status can still come back without
+      // a metadata.music array, which previously threw and surfaced as a 500.
+      const musicData = response.data.metadata?.music?.[0];
       if (!musicData?.title || !musicData?.artists?.[0]?.name) {
         return res.status(502).send('Song metadata incomplete from detection service');
       }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -124,9 +124,18 @@ function MainApp() {
 
   // Poll for detected songs every 3 seconds
   useEffect(() => {
+    // Don't flag the orbit on every failed poll; only react once the
+    // backend looks genuinely unreachable, then keep retrying quietly.
+    const MAX_CONSECUTIVE_POLL_ERRORS = 5;
+    let consecutivePollErrors = 0;
+
     const fetchTrack = async () => {
       try {
         const response = await authFetch(`${backendUrl}/detected-song`);
+        if (!response.ok) {
+          throw new Error(`Polling failed with status ${response.status}`);
+        }
+        consecutivePollErrors = 0;
         const data = await response.json();
 
         if (data?.title && data?.artist) {
@@ -141,8 +150,11 @@ function MainApp() {
           }
         }
       } catch (error) {
+        consecutivePollErrors += 1;
         console.error('Error fetching detected song:', error);
-        flashOrbitState('error', 700);
+        if (consecutivePollErrors === MAX_CONSECUTIVE_POLL_ERRORS) {
+          flashOrbitState('error', 2000);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
Two targeted fixes toward #30 (streamline fetch process):

**Frontend (`App.js`)**
- The detected-song poll called `response.json()` without checking `response.ok`, and flashed the error orbit on *every* failed attempt — a briefly unavailable backend caused constant error flicker every 3 seconds
- The poll now checks `response.ok`, tolerates transient failures, and only signals an error after 5 consecutive failures (then keeps retrying quietly)

**Backend (`detectSong.js`)**
- An ACRCloud success status (`code === 0`) without a `metadata.music` array threw a `TypeError` and surfaced as a generic 500
- The access chain is now guarded with optional chaining and returns the existing 502 incomplete-metadata response instead

The larger streamlining idea in #30 (replacing 3-second polling with SSE/WebSocket push) is intentionally out of scope here — left a note on the issue.

## Testing
- `node --check backend/routes/detectSong.js` passes
- `esbuild` parses `frontend/src/App.js` cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkyJimQmCvkjbfQ9dz9zR)_