### PR TITLE
Return JSON errors for malformed and oversized request bodies

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -168,7 +168,22 @@ app.use((err, req, res, next) => {
     if (err && err.code === 'LIMIT_FILE_SIZE') {
         return res.status(413).json({ error: 'Audio file is too large' });
     }
+    if (err && err.type === 'entity.parse.failed') {
+        return res.status(400).json({ error: 'Invalid JSON in request body' });
+    }
+    if (err && err.type === 'entity.too.large') {
+        return res.status(413).json({ error: 'Request body is too large' });
+    }
     return next(err);
+});
+
+// Final JSON error handler — never leak stack traces as HTML
+app.use((err, req, res, next) => {
+    if (res.headersSent) {
+        return next(err);
+    }
+    console.error('Unhandled error:', err);
+    return res.status(err.status || 500).json({ error: 'Internal server error' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Testing summary

- `node --check` passes on backend sources; backend deps install cleanly.
- Started the backend and smoke-tested error paths: a malformed JSON body previously fell through to Express's default HTML error handler; it now returns `400 {"error":"Invalid JSON in request body"}` (verified live).

## Fixes

- Malformed JSON request bodies → 400 with a JSON payload.
- Oversized request bodies → 413 with a JSON payload.
- Added a final error handler so any unhandled error returns JSON instead of leaking an HTML stack trace.

Note: GitHub reports 14 Dependabot vulnerabilities (4 high) on the default branch's dependency tree — worth a `npm audit fix` pass separately.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_