### PR TITLE
fix(albumArt): handle upstream stream errors in image proxy

### DIFF
--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -11,6 +11,8 @@ const router = express.Router();
 
 const API_KEY = process.env.LAST_API_KEY;
 
+const PROXY_ERROR_MESSAGE = 'Failed to fetch image';
+
 const extractLargestImage = (images) => {
   /**
    * Helper function to extract the largest image URL from Last.fm image array.
@@ -219,8 +221,11 @@ router.get('/proxy', async (req, res) => {
       timeout: 10000,
     });
 
-    res.setHeader('Content-Type', imageRes.headers['content-type'] || 'image/jpeg');
-    res.setHeader('Cache-Control', 'public, max-age=86400'); // cache 24h in browser
+    const imageHeaders = {
+      'Content-Type': imageRes.headers['content-type'] || 'image/jpeg',
+      'Cache-Control': 'public, max-age=86400', // cache 24h in browser
+    };
+    res.set(imageHeaders);
 
     // Guard against the upstream stream erroring out mid-pipe (e.g. CDN
     // connection drop). Without this listener the 'error' event is unhandled
@@ -231,16 +236,15 @@ router.get('/proxy', async (req, res) => {
         res.destroy(streamError);
       } else {
         // Drop the image headers so the 502 isn't served (and cached) as an image.
-        res.removeHeader('Content-Type');
-        res.removeHeader('Cache-Control');
-        res.status(502).send('Failed to fetch image');
+        Object.keys(imageHeaders).forEach((header) => res.removeHeader(header));
+        res.status(502).send(PROXY_ERROR_MESSAGE);
       }
     });
 
     imageRes.data.pipe(res);
   } catch (error) {
     console.error('Image proxy error:', error.message);
-    res.status(502).send('Failed to fetch image');
+    res.status(502).send(PROXY_ERROR_MESSAGE);
   }
 });
 

--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -225,12 +225,15 @@ router.get('/proxy', async (req, res) => {
     // Guard against the upstream stream erroring out mid-pipe (e.g. CDN
     // connection drop). Without this listener the 'error' event is unhandled
     // and crashes the process while the client hangs.
-    imageRes.data.on('error', (error) => {
-      console.error('Image proxy stream error:', error.message);
-      if (!res.headersSent) {
-        res.status(502).send('Failed to fetch image');
+    imageRes.data.once('error', (streamError) => {
+      console.error('Image proxy stream error:', streamError.message);
+      if (res.headersSent) {
+        res.destroy(streamError);
       } else {
-        res.destroy(error);
+        // Drop the image headers so the 502 isn't served (and cached) as an image.
+        res.removeHeader('Content-Type');
+        res.removeHeader('Cache-Control');
+        res.status(502).send('Failed to fetch image');
       }
     });
 

--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -221,6 +221,19 @@ router.get('/proxy', async (req, res) => {
 
     res.setHeader('Content-Type', imageRes.headers['content-type'] || 'image/jpeg');
     res.setHeader('Cache-Control', 'public, max-age=86400'); // cache 24h in browser
+
+    // Guard against the upstream stream erroring out mid-pipe (e.g. CDN
+    // connection drop). Without this listener the 'error' event is unhandled
+    // and crashes the process while the client hangs.
+    imageRes.data.on('error', (error) => {
+      console.error('Image proxy stream error:', error.message);
+      if (!res.headersSent) {
+        res.status(502).send('Failed to fetch image');
+      } else {
+        res.destroy(error);
+      }
+    });
+
     imageRes.data.pipe(res);
   } catch (error) {
     console.error('Image proxy error:', error.message);


### PR DESCRIPTION
## Summary

The `/album-art/proxy` endpoint streams a Last.fm CDN image to the client with `imageRes.data.pipe(res)` but never attached an `error` listener to the upstream stream. If the upstream connection drops **after** headers are received (a common CDN hiccup), Node emits an unhandled `'error'` event on the readable stream — which **crashes the Node process** and leaves the client request hanging until timeout.

The surrounding `try/catch` only covers the initial `axios.get` (connection setup); it does **not** catch errors emitted on the stream once piping has begun.

## Fix

Attach an `error` handler to the upstream stream before piping:
- if response headers haven't been sent yet → respond `502 Failed to fetch image`
- otherwise (headers already flushed) → `res.destroy(error)` to tear the response down cleanly

A single CDN drop can no longer take down the backend.

## Testing

No test framework is configured in the repo, so I verified manually:
- `node -c` syntax check passes and the route module loads cleanly.
- Wrote a throwaway integration test: mounted the router, stubbed `axios.get` to return a `PassThrough` stream, fired an `error` event mid-pipe, and confirmed the server responds **502** and the process **does not crash** (previously this scenario would throw an unhandled stream error). Test removed; not committed.

## Scope

Self-contained, 13-line addition to one route handler — no behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CW4Nrxt6sYM25fMQKXVBtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CW4Nrxt6sYM25fMQKXVBtX)_