### PR TITLE
redesign(ui): single-focus "stage" layout + de-AI styling pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scrozam!
+# Scrozam
 
 ![Status](https://img.shields.io/badge/status-active-brightgreen)
 ![Frontend](https://img.shields.io/badge/frontend-React-61DAFB?logo=react)
@@ -13,6 +13,7 @@
 <img width="1512" height="862" alt="Screenshot 2026-02-26 at 10 11 48 PM" src="https://github.com/user-attachments/assets/7622d50f-e76d-4864-a1ee-14a055d14a2f" />
 
 ## Features
+
 - **Google SSO** — sign in with your Google account; no password required.
 - **Last.fm OAuth** — connect your Last.fm account in-app; no manual session key steps.
 - Detects songs from audio input using ACRCloud.
@@ -23,6 +24,7 @@
 ## Setup Instructions
 
 ### Prerequisites
+
 - Node.js and npm installed on your machine.
 - ACRCloud and Last.fm API accounts.
 - A Google Cloud project with an OAuth 2.0 Web Client ID ([create one here](https://console.cloud.google.com/)).
@@ -38,6 +40,7 @@
 2. **Add environment variables**
 
    Create a `.env` file in the `backend` directory (see `backend/.env.example`):
+
    ```env
    ACR_URL="your_acrcloud_url"
    ACR_ACCESS_KEY="your_acr_access_key"
@@ -52,17 +55,20 @@
    ```
 
    Create a `.env` file in the `frontend` directory (see `frontend/.env.example`):
+
    ```env
    REACT_APP_GOOGLE_CLIENT_ID="your_google_oauth_client_id.apps.googleusercontent.com"
    ```
 
 3. **Configure your Last.fm app callback**
    - In your [Last.fm API account settings](https://www.last.fm/api/accounts), set the callback URL to:
-     ```
+
+     ```plaintext
      http://localhost:3000/auth/lastfm/callback
      ```
 
 4. **Start the backend server**
+
    ```bash
    cd backend
    npm install
@@ -70,15 +76,17 @@
    ```
 
 5. **Start the frontend**
+
    ```bash
    cd frontend
    npm install
    npm start
    ```
+
    Type `y` if prompted to use port 3001.
 
 6. **Sign in**
-   - Open http://localhost:3001.
+   - Open <http://localhost:3001>.
    - Click **Sign in with Google**.
    - After Google authentication, click **Connect Last.fm** and authorise Scrozam.
    - You're now fully signed in and ready to scrobble.
@@ -89,7 +97,8 @@
    - Enable **Continuous Listening Mode** to auto-detect song changes without stopping.
 
 Sample backend output:
-```
+
+```plaintext
 ACRCloud Response: { ... }
 Full music data from ACRCloud: { ... }
 Detected Song -> Title: Killah, Artist: Lady Gaga
@@ -100,7 +109,8 @@ Detected Song -> Title: Killah, Artist: Lady Gaga
 ```
 
 To avoid duplication, if the same song is detected you will see:
-```
+
+```plaintext
 📭 No new song detected, returning null.
 ```
 
@@ -108,7 +118,7 @@ To avoid duplication, if the same song is detected you will see:
 <summary>It is normal to see the following when a song first switches:</summary>
 <br>
 
-```
+```plaintext
 ACRCloud Response: { status: { code: 1001, version: '1.0', msg: 'No result' } }
 No result detected. Retrying...
 📭 No new song detected, returning null.
@@ -133,7 +143,7 @@ The song **will** update eventually, usually well before the midpoint of the cur
 
 ### Project Structure
 
-```
+```plaintext
 backend/
   app.js              — Express server, session & auth middleware
   userStore.js        — In-memory user profiles & Last.fm session keys

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,7 +6,7 @@
   --accent: #E80922;
   --accent-light: #FF3B52;
   --accent-rgb: 232, 9, 34;
-  --font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 * {
@@ -17,22 +17,11 @@
   min-height: 100vh;
   font-family: var(--font-family);
   color: #f3f5ff;
-  background: radial-gradient(95% 90% at 50% 0%, rgba(var(--accent-rgb), 0.16), transparent 60%),
-              linear-gradient(145deg, var(--bg-start) 0%, var(--bg-end) 100%);
+  background: var(--bg-start);
 }
 
 .app-shell {
   position: relative;
-}
-
-.app-shell::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(90deg, transparent 0%, rgba(var(--accent-rgb), 0.07) 50%, transparent 100%);
-  filter: blur(100px);
-  opacity: 0.55;
 }
 
 /* ── Auth / login ─────────────────────────────────────────────────────────── */
@@ -50,44 +39,38 @@
 }
 
 .login-card {
-  width: min(100%, 520px);
-  background: rgba(28, 33, 51, 0.88);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 24px;
-  padding: 42px;
+  width: min(100%, 420px);
+  background: #1c2133;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 14px;
+  padding: 36px 32px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
   text-align: center;
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
-  animation: fadeInUp 0.35s ease-out;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .login-logo {
-  width: 72px;
-  height: 72px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
 }
 
 .login-title {
   margin: 0;
-  font-size: clamp(2rem, 2.4vw, 2.6rem);
-  line-height: 1.1;
+  font-size: 1.6rem;
+  line-height: 1.2;
   font-weight: 700;
-  letter-spacing: -0.015em;
-  background: linear-gradient(120deg, #f3f5ff 0%, var(--accent-light) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  letter-spacing: -0.01em;
+  color: #f3f5ff;
 }
 
 .login-subtitle {
   margin: 0;
   color: #b4b9cf;
-  font-size: 1rem;
+  font-size: 0.95rem;
   line-height: 1.6;
 }
 
@@ -134,32 +117,22 @@
 .login-lastfm-btn {
   width: 100%;
   border: none;
-  border-radius: 999px;
-  padding: 14px 20px;
-  background: linear-gradient(130deg, var(--accent) 0%, var(--accent-light) 100%);
+  border-radius: 8px;
+  padding: 12px 20px;
+  background: var(--accent);
   color: #fff;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   gap: 10px;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.95rem;
   cursor: pointer;
-  box-shadow: 0 10px 24px rgba(var(--accent-rgb), 0.4);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  transition: background 0.15s ease;
 }
 
 .login-lastfm-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 28px rgba(var(--accent-rgb), 0.48);
-}
-
-.login-lastfm-btn:active {
-  transform: translateY(0);
-}
-
-.lastfm-icon {
-  font-size: 1.05rem;
+  background: var(--accent-light);
 }
 
 .login-footer {
@@ -180,10 +153,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 24px;
-  background: rgba(11, 12, 20, 0.84);
+  background: #0b0c14;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
 }
 
 .app-brand-mini {
@@ -226,7 +197,7 @@
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(255, 255, 255, 0.02);
   color: #d9deef;
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 8px 14px;
   font-size: 0.85rem;
   font-weight: 500;
@@ -253,12 +224,9 @@
 
 .now-playing-panel,
 .control-panel {
-  background: rgba(28, 33, 51, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 24px;
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 22px 55px rgba(0, 0, 0, 0.4);
+  background: #161a28;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
 }
 
 .now-playing-panel {
@@ -298,10 +266,10 @@
 }
 
 .album-art-container {
-  border-radius: 18px;
+  border-radius: 12px;
   overflow: hidden;
   background: rgba(11, 12, 20, 0.58);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .album-art,
@@ -316,15 +284,15 @@
 }
 
 .album-art-placeholder {
-  display: grid;
-  place-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   padding: 20px;
   text-align: center;
   color: #8087a3;
   font-size: 0.95rem;
   line-height: 1.5;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  border-radius: 16px;
 }
 
 .album-art-empty {
@@ -332,17 +300,15 @@
 }
 
 .album-art-mark {
-  width: 64px;
-  height: 64px;
-  opacity: 0.6;
+  width: 56px;
+  height: 56px;
+  opacity: 0.5;
 }
 
 .track-info {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  border-left: 3px solid rgba(var(--accent-rgb), 0.85);
-  padding-left: 14px;
 }
 
 .track-title {
@@ -371,15 +337,11 @@
 
 .control-title {
   margin: 0;
-  font-size: clamp(1.7rem, 2.6vw, 2.4rem);
-  line-height: 1.1;
-  letter-spacing: -0.02em;
+  font-size: 1.5rem;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
   font-weight: 700;
-  max-width: 16ch;
-  background: linear-gradient(120deg, #f3f5ff 0%, var(--accent-light) 90%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #f3f5ff;
 }
 
 .toggle-container {
@@ -391,8 +353,8 @@
   grid-template-columns: auto 1fr;
   gap: 12px;
   align-items: center;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
   background: rgba(11, 12, 20, 0.56);
   padding: 12px 14px;
   cursor: pointer;
@@ -462,37 +424,33 @@
 
 .button-group button {
   border: none;
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 14px 18px;
   min-height: 48px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  transition: background 0.15s ease;
   color: #ffffff;
   flex: 1;
 }
 
 .button-group button:first-child {
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-light) 100%);
-  box-shadow: 0 12px 28px rgba(var(--accent-rgb), 0.38);
+  background: var(--accent);
 }
 
 .button-group button:first-child:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(var(--accent-rgb), 0.45);
+  background: var(--accent-light);
 }
 
 .button-group button:disabled {
-  opacity: 0.65;
+  opacity: 0.55;
   cursor: not-allowed;
-  box-shadow: none;
 }
 
 .stop-button {
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.22);
-  box-shadow: none;
 }
 
 .stop-button:hover:not(:disabled) {
@@ -643,13 +601,11 @@
   top: calc(100% + 10px);
   right: 0;
   width: 248px;
-  border-radius: 16px;
+  border-radius: 12px;
   padding: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(20, 24, 39, 0.96);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.46);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #1c2133;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .settings-heading {
@@ -775,17 +731,6 @@
   100% {
     transform: scale(1);
     opacity: 1;
-  }
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(16px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -327,46 +327,38 @@
   border-radius: 16px;
 }
 
+.album-art-empty {
+  gap: 16px;
+}
+
+.album-art-mark {
+  width: 64px;
+  height: 64px;
+  opacity: 0.6;
+}
+
 .track-info {
-  border-radius: 16px;
-  padding: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(11, 12, 20, 0.5);
-}
-
-.track-info h2 {
-  margin: 0 0 14px;
-  color: #f3f5ff;
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.track-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   border-left: 3px solid rgba(var(--accent-rgb), 0.85);
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 10px;
-  padding: 12px;
+  padding-left: 14px;
 }
 
-.track-detail + .track-detail {
-  margin-top: 10px;
-}
-
-.track-detail strong {
-  display: block;
-  margin-bottom: 6px;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #b4b9cf;
-  font-family: 'Roboto Mono', 'Courier New', monospace;
-}
-
-.track-detail span {
+.track-title {
+  margin: 0;
   color: #f3f5ff;
-  font-size: 1.02rem;
-  line-height: 1.45;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.track-artist {
+  margin: 0;
+  color: #b4b9cf;
+  font-size: 1rem;
+  line-height: 1.4;
 }
 
 .control-panel {
@@ -377,11 +369,11 @@
   gap: 20px;
 }
 
-.main-title {
+.control-title {
   margin: 0;
-  font-size: clamp(2.1rem, 3.3vw, 3.4rem);
-  line-height: 1.05;
-  letter-spacing: -0.025em;
+  font-size: clamp(1.7rem, 2.6vw, 2.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
   font-weight: 700;
   max-width: 16ch;
   background: linear-gradient(120deg, #f3f5ff 0%, var(--accent-light) 90%);
@@ -390,15 +382,8 @@
   background-clip: text;
 }
 
-.subtitle {
-  margin: 0;
-  color: #b4b9cf;
-  font-size: 1.08rem;
-  line-height: 1.65;
-}
-
 .toggle-container {
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .mode-switch {
@@ -469,13 +454,6 @@
   color: #8087a3;
 }
 
-.controls-section {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 12px;
-}
-
 .button-group {
   display: flex;
   width: 100%;
@@ -519,14 +497,6 @@
 
 .stop-button:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.12);
-}
-
-.control-footnote {
-  margin: 0;
-  color: #8087a3;
-  font-size: 0.86rem;
-  line-height: 1.5;
-  font-family: 'Roboto Mono', 'Courier New', monospace;
 }
 
 /* ── Orbit dot ────────────────────────────────────────────────────────────── */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -211,176 +211,138 @@
   color: #fff;
 }
 
-/* ── Main authenticated layout ────────────────────────────────────────────── */
+/* ── Stage (single-focus authenticated layout) ────────────────────────────── */
 
-.music-layout {
-  width: min(1160px, 100% - 48px);
-  margin: 28px auto 42px;
-  display: grid;
-  grid-template-columns: minmax(340px, 1.05fr) minmax(340px, 0.95fr);
-  gap: 24px;
-  align-items: stretch;
-}
-
-.now-playing-panel,
-.control-panel {
-  background: #161a28;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
-}
-
-.now-playing-panel {
-  padding: 24px;
+.stage {
+  width: min(560px, 100% - 40px);
+  margin: 0 auto;
+  padding: 56px 0 72px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
-}
-
-.panel-head {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  text-align: center;
 }
 
-.panel-label {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.75rem;
-  color: #b4b9cf;
-  font-family: 'Roboto Mono', 'Courier New', monospace;
+/* The record itself is the primary control: tap to listen, fills with art. */
+.stage-disc {
+  position: relative;
+  width: clamp(220px, 44vw, 300px);
+  aspect-ratio: 1;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: #07080e;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06),
+              inset 0 0 70px rgba(0, 0, 0, 0.7);
+  transition: transform 0.18s ease;
 }
 
-.status-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(11, 12, 20, 0.5);
-  color: #d3d8ec;
-  font-size: 0.84rem;
-  padding: 8px 12px;
-  white-space: nowrap;
+.stage-disc:hover {
+  transform: scale(1.015);
 }
 
-.album-art-container {
-  border-radius: 12px;
-  overflow: hidden;
-  background: rgba(11, 12, 20, 0.58);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+.stage-disc:active {
+  transform: scale(0.99);
 }
 
-.album-art,
-.album-art-placeholder {
+.stage-disc.is-loading {
+  opacity: 0.78;
+}
+
+.stage-disc-art {
   width: 100%;
-  aspect-ratio: 1 / 1;
-}
-
-.album-art {
+  height: 100%;
   object-fit: cover;
+  border-radius: 50%;
   display: block;
 }
 
-.album-art-placeholder {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-  text-align: center;
-  color: #8087a3;
-  font-size: 0.95rem;
-  line-height: 1.5;
+.stage-disc-mark {
+  width: 66%;
+  height: 66%;
+  object-fit: contain;
 }
 
-.album-art-empty {
-  gap: 16px;
+/* Expanding ring while actively listening. */
+.stage-disc::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  pointer-events: none;
 }
 
-.album-art-mark {
-  width: 56px;
-  height: 56px;
-  opacity: 0.5;
+.stage-disc[data-state="success"]::after {
+  border-color: rgba(var(--accent-rgb), 0.7);
 }
 
-.track-info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.stage-disc[data-state="error"]::after {
+  border-color: rgba(248, 113, 113, 0.7);
 }
 
-.track-title {
+.stage-track {
+  margin-top: 30px;
+  min-height: 64px;
+}
+
+.stage-title {
   margin: 0;
-  color: #f3f5ff;
-  font-size: 1.35rem;
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
   font-weight: 700;
   line-height: 1.2;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
+  color: #f3f5ff;
 }
 
-.track-artist {
-  margin: 0;
+.stage-artist {
+  margin: 6px 0 0;
+  font-size: 1.05rem;
   color: #b4b9cf;
-  font-size: 1rem;
-  line-height: 1.4;
 }
 
-.control-panel {
-  padding: 32px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 20px;
-}
-
-.control-title {
+.stage-cta {
   margin: 0;
-  font-size: 1.5rem;
-  line-height: 1.2;
-  letter-spacing: -0.01em;
-  font-weight: 700;
-  color: #f3f5ff;
+  font-size: 1.05rem;
+  color: #8087a3;
 }
 
-.toggle-container {
-  margin-top: 4px;
-}
-
-.mode-switch {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 12px;
+/* Continuous-mode toggle: compact, inline. */
+.continuous-toggle {
+  margin-top: 24px;
+  display: inline-flex;
   align-items: center;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  background: rgba(11, 12, 20, 0.56);
-  padding: 12px 14px;
+  gap: 10px;
+  color: #b4b9cf;
+  font-size: 0.9rem;
   cursor: pointer;
   -webkit-user-select: none;
   user-select: none;
 }
 
-.mode-switch input[type="checkbox"] {
+.continuous-toggle input[type="checkbox"] {
   position: absolute;
   opacity: 0;
   pointer-events: none;
 }
 
 .switch-track {
-  width: 44px;
-  height: 24px;
+  width: 40px;
+  height: 22px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(255, 255, 255, 0.08);
   position: relative;
+  flex: 0 0 auto;
   transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .switch-thumb {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: #f3f5ff;
   position: absolute;
@@ -389,72 +351,93 @@
   transition: transform 0.2s ease;
 }
 
-.mode-switch input[type="checkbox"]:checked + .switch-track {
-  background: rgba(var(--accent-rgb), 0.28);
+.continuous-toggle input[type="checkbox"]:checked + .switch-track {
+  background: rgba(var(--accent-rgb), 0.3);
   border-color: rgba(var(--accent-rgb), 0.8);
 }
 
-.mode-switch input[type="checkbox"]:checked + .switch-track .switch-thumb {
-  transform: translateX(20px);
-  background: #fff;
+.continuous-toggle input[type="checkbox"]:checked + .switch-track .switch-thumb {
+  transform: translateX(18px);
 }
 
-.mode-copy {
+/* Listening log. */
+.history {
+  width: 100%;
+  margin-top: 44px;
+  text-align: left;
+}
+
+.history-label {
+  margin: 0 0 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  color: #8087a3;
+  font-family: 'Roboto Mono', 'Courier New', monospace;
+}
+
+.history-empty {
+  margin: 12px 0 0;
+  color: #8087a3;
+  font-size: 0.9rem;
+}
+
+.history-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.history-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.history-thumb {
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+
+.history-thumb--empty {
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.history-meta {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-}
-
-.mode-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #f3f5ff;
-}
-
-.mode-subtitle {
-  font-size: 0.8rem;
-  color: #8087a3;
-}
-
-.button-group {
-  display: flex;
-  width: 100%;
-  gap: 10px;
-}
-
-.button-group button {
-  border: none;
-  border-radius: 8px;
-  padding: 14px 18px;
-  min-height: 48px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s ease;
-  color: #ffffff;
+  min-width: 0;
   flex: 1;
 }
 
-.button-group button:first-child {
-  background: var(--accent);
+.history-track {
+  color: #f3f5ff;
+  font-size: 0.92rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.button-group button:first-child:hover:not(:disabled) {
-  background: var(--accent-light);
+.history-artist {
+  color: #8087a3;
+  font-size: 0.82rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.button-group button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.stop-button {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.22);
-}
-
-.stop-button:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.12);
+.history-time {
+  color: #8087a3;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
 }
 
 /* ── Orbit dot ────────────────────────────────────────────────────────────── */
@@ -734,27 +717,42 @@
   }
 }
 
-button:focus-visible,
-input:focus-visible,
-.mode-switch:focus-within {
-  outline: 2px solid rgba(var(--accent-rgb), 0.9);
-  outline-offset: 2px;
+/* The record spins and the ring pulses only while listening (brand rule:
+   continuous rotation must be tied to the listening state). */
+@keyframes discSpin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-@media (max-width: 980px) {
-  .music-layout {
-    width: min(100% - 28px, 760px);
-    grid-template-columns: 1fr;
+@keyframes discPulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1.22);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .stage-disc[data-state="listening"] .stage-disc-art,
+  .stage-disc[data-state="listening"] .stage-disc-mark {
+    animation: discSpin 8s linear infinite;
   }
 
-  .control-panel,
-  .now-playing-panel {
-    padding: 22px;
+  .stage-disc[data-state="listening"]::after {
+    border-color: rgba(var(--accent-rgb), 0.55);
+    animation: discPulse 1.8s ease-out infinite;
   }
+}
 
-  .button-group {
-    flex-direction: column;
-  }
+button:focus-visible,
+input:focus-visible,
+.continuous-toggle:focus-within {
+  outline: 2px solid rgba(var(--accent-rgb), 0.9);
+  outline-offset: 2px;
 }
 
 @media (max-width: 760px) {
@@ -778,16 +776,15 @@ input:focus-visible,
     font-size: 0.76rem;
   }
 
-  .music-layout {
-    margin-top: 18px;
+  .stage {
+    padding-top: 36px;
   }
 
   .login-card {
     padding: 28px 20px;
-    border-radius: 18px;
   }
 
   .login-title {
-    font-size: 1.8rem;
+    font-size: 1.5rem;
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,7 @@ function MainApp() {
    * both a Google session and a connected Last.fm account.
    */
   const { user, logout, authFetch, backendUrl } = useAuth();
+  const recordMarkSrc = `${process.env.PUBLIC_URL}/branding/signal-vinyl/primary/signal-vinyl-primary-128.png`;
 
   const [trackInfo, setTrackInfo] = useState(null);
   const [isListening, setIsListening] = useState(false);
@@ -265,50 +266,35 @@ function MainApp() {
             <p className="panel-label">Now Playing</p>
             <div className="status-indicator">
               <OrbitDot state={orbitState} size="xs" />
-              <span>{isListening ? 'Listening for music...' : 'Ready to listen'}</span>
+              <span>{isListening ? 'Listening…' : 'Ready to listen'}</span>
             </div>
           </div>
 
           <div className="album-art-container">
             {albumArtLoading && (
-              <div className="album-art-placeholder">Loading album art...</div>
+              <div className="album-art-placeholder">Loading album art…</div>
             )}
             {!albumArtLoading && albumArt && (
-              <img src={albumArt} alt="Album Art" className="album-art" />
+              <img src={albumArt} alt={trackInfo ? `${trackInfo.title} album art` : 'Album art'} className="album-art" />
             )}
             {!albumArtLoading && !albumArt && (
-              <div className="album-art-placeholder">Waiting for the first detected track</div>
+              <div className="album-art-placeholder album-art-empty">
+                <img src={recordMarkSrc} alt="" className="album-art-mark" aria-hidden="true" />
+                <span>{isListening ? 'Listening for music…' : 'Press Start — your detected track shows up here'}</span>
+              </div>
             )}
           </div>
 
-          <div className="track-info">
-            {trackInfo ? (
-              <>
-                <h2>Detected Track</h2>
-                <div className="track-detail">
-                  <strong>Title</strong>
-                  <span>{trackInfo.title}</span>
-                </div>
-                <div className="track-detail">
-                  <strong>Artist</strong>
-                  <span>{trackInfo.artist}</span>
-                </div>
-              </>
-            ) : (
-              <>
-                <h2>Listening Queue</h2>
-                <div className="track-detail">
-                  <strong>Status</strong>
-                  <span>Start listening to capture your first song.</span>
-                </div>
-              </>
-            )}
-          </div>
+          {trackInfo && (
+            <div className="track-info">
+              <p className="track-title">{trackInfo.title}</p>
+              <p className="track-artist">{trackInfo.artist}</p>
+            </div>
+          )}
         </section>
 
         <section className="control-panel">
-          <h1 className="main-title">Hear it. Catch it. Scrobble it.</h1>
-          <p className="subtitle">Ambient sound to Last.fm, instantly.</p>
+          <h1 className="control-title">Detect what&apos;s playing</h1>
 
           <div className="toggle-container">
             <label className="mode-switch" htmlFor="continuousModeToggle">
@@ -328,21 +314,15 @@ function MainApp() {
             </label>
           </div>
 
-          <div className="controls-section">
-            <div className="button-group">
-              <button onClick={handleStartListening} disabled={isListening}>
-                {isListening ? '🎧 Listening...' : '🎵 Start Listening'}
+          <div className="button-group">
+            <button onClick={handleStartListening} disabled={isListening}>
+              {isListening ? '🎧 Listening…' : '🎵 Start Listening'}
+            </button>
+            {isListening && (
+              <button onClick={handleStopListening} className="stop-button">
+                ⏹️ Stop
               </button>
-              {isListening && (
-                <button onClick={handleStopListening} className="stop-button">
-                  ⏹️ Stop Listening
-                </button>
-              )}
-            </div>
-
-            <p className="control-footnote">
-              Scrozam detects tracks and scrobbles to Last.fm automatically.
-            </p>
+            )}
           </div>
         </section>
       </main>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,16 @@ import LoginPage from './components/LoginPage';
 import SettingsDropdown from './components/SettingsDropdown';
 import OrbitDot from './components/OrbitDot';
 
+// Compact relative timestamp for the listening log ("now", "4m", "2h").
+function timeAgo(ts, now) {
+  const seconds = Math.floor((now - ts) / 1000);
+  if (seconds < 45) return 'now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h`;
+}
+
 // ── Main app (only rendered when fully authenticated) ─────────────────────────
 
 function MainApp() {
@@ -29,6 +39,8 @@ function MainApp() {
   const [albumArt, setAlbumArt] = useState(null);
   const [albumArtLoading, setAlbumArtLoading] = useState(false);
   const [transientOrbitState, setTransientOrbitState] = useState(null);
+  const [history, setHistory] = useState([]); // this session's detected tracks
+  const [now, setNow] = useState(() => Date.now());
 
   const mediaRecorderRef = useRef(null);
   const streamRef = useRef(null);
@@ -51,14 +63,27 @@ function MainApp() {
 
   const orbitState = transientOrbitState || (isListening ? 'listening' : 'ready');
 
-  // Empty-state copy for the album canvas. When a track is already detected
-  // but has no artwork, say so — don't tell the user to press Start again.
-  let emptyArtMessage = 'Press Start to detect what’s playing';
-  if (trackInfo) {
-    emptyArtMessage = 'No artwork for this track';
-  } else if (isListening) {
-    emptyArtMessage = 'Listening for music…';
-  }
+  // Prompt shown under the disc before/while listening (a detected track
+  // replaces it with the title + artist).
+  let discPrompt = 'Tap the record to listen';
+  if (isListening) discPrompt = 'Listening… tap to stop';
+
+  // Append a freshly detected track to the session log (dedupe consecutive
+  // repeats so a held track isn't logged on every poll).
+  const addToHistory = useCallback((artist, title) => {
+    setHistory((prev) => {
+      const key = `${artist}-${title}`;
+      if (prev[0]?.key === key) return prev;
+      const entry = { key, artist, title, art: null, at: Date.now() };
+      return [entry, ...prev].slice(0, 25);
+    });
+  }, []);
+
+  // Keep relative timestamps in the log fresh.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30000);
+    return () => clearInterval(id);
+  }, []);
 
   const fetchAlbumArt = useCallback(async (artist, title) => {
     /**
@@ -89,6 +114,11 @@ function MainApp() {
         if (data.albumArt) {
           setAlbumArt(data.albumArt);
           lastAlbumArtTrack.current = trackKey;
+          // Backfill the matching log entry's thumbnail (reuses this fetch,
+          // no extra request).
+          setHistory((prev) =>
+            prev.map((e) => (e.key === trackKey && !e.art ? { ...e, art: data.albumArt } : e))
+          );
         }
       } else {
         console.error('Failed to fetch album art:', response.status);
@@ -158,6 +188,7 @@ function MainApp() {
           // Only fetch art / scrobble once per unique track (don't call inside setState)
           if (trackKey !== lastPolledTrack.current) {
             lastPolledTrack.current = trackKey;
+            addToHistory(data.artist, data.title);
             fetchAlbumArt(data.artist, data.title);
             handleNewTrack(data.artist, data.title);
           }
@@ -173,7 +204,7 @@ function MainApp() {
 
     const interval = setInterval(fetchTrack, 3000);
     return () => clearInterval(interval);
-  }, [authFetch, backendUrl, fetchAlbumArt, handleNewTrack, flashOrbitState]);
+  }, [authFetch, backendUrl, fetchAlbumArt, handleNewTrack, flashOrbitState, addToHistory]);
 
   const stopStream = useCallback(() => {
     setIsListening(false);
@@ -221,6 +252,7 @@ function MainApp() {
 
             const songData = await response.json();
             setTrackInfo(songData);
+            addToHistory(songData.artist, songData.title);
             fetchAlbumArt(songData.artist, songData.title);
 
             if (continuousListening) setTimeout(startRecording, 500);
@@ -272,70 +304,73 @@ function MainApp() {
         <button className="logout-btn" onClick={logout}>Sign out</button>
       </div>
 
-      <main className="music-layout">
-        <section className="now-playing-panel" aria-live="polite">
-          <div className="panel-head">
-            <p className="panel-label">Now Playing</p>
-            <div className="status-indicator">
-              <OrbitDot state={orbitState} size="xs" />
-              <span>{isListening ? 'Listening…' : 'Ready to listen'}</span>
-            </div>
-          </div>
-
-          <div className="album-art-container">
-            {albumArtLoading && (
-              <div className="album-art-placeholder">Loading album art…</div>
-            )}
-            {!albumArtLoading && albumArt && (
-              <img src={albumArt} alt={trackInfo ? `${trackInfo.title} album art` : 'Album art'} className="album-art" />
-            )}
-            {!albumArtLoading && !albumArt && (
-              <div className="album-art-placeholder album-art-empty">
-                <img src={recordMarkSrc} alt="" className="album-art-mark" aria-hidden="true" />
-                <span>{emptyArtMessage}</span>
-              </div>
-            )}
-          </div>
-
-          {trackInfo && (
-            <div className="track-info">
-              <p className="track-title">{trackInfo.title}</p>
-              <p className="track-artist">{trackInfo.artist}</p>
-            </div>
+      <main className="stage">
+        <button
+          type="button"
+          className={`stage-disc${albumArtLoading ? ' is-loading' : ''}`}
+          data-state={orbitState}
+          onClick={isListening ? handleStopListening : handleStartListening}
+          aria-label={isListening ? 'Stop listening' : 'Start listening'}
+        >
+          {albumArt ? (
+            <img
+              className="stage-disc-art"
+              src={albumArt}
+              alt={trackInfo ? `${trackInfo.title} album art` : 'Album art'}
+            />
+          ) : (
+            <img className="stage-disc-mark" src={recordMarkSrc} alt="" aria-hidden="true" />
           )}
-        </section>
+        </button>
 
-        <section className="control-panel">
-          <h1 className="control-title">Detect what&apos;s playing</h1>
+        <div className="stage-track" aria-live="polite">
+          {trackInfo ? (
+            <>
+              <h1 className="stage-title">{trackInfo.title}</h1>
+              <p className="stage-artist">{trackInfo.artist}</p>
+            </>
+          ) : (
+            <p className="stage-cta">{discPrompt}</p>
+          )}
+        </div>
 
-          <div className="toggle-container">
-            <label className="mode-switch" htmlFor="continuousModeToggle">
-              <input
-                id="continuousModeToggle"
-                type="checkbox"
-                checked={continuousListening}
-                onChange={(e) => setContinuousListening(e.target.checked)}
-              />
-              <span className="switch-track" aria-hidden="true">
-                <span className="switch-thumb" />
-              </span>
-              <span className="mode-copy">
-                <span className="mode-title">Continuous Mode</span>
-                <span className="mode-subtitle">Keep listening between detections</span>
-              </span>
-            </label>
-          </div>
+        <label className="continuous-toggle" htmlFor="continuousModeToggle">
+          <input
+            id="continuousModeToggle"
+            type="checkbox"
+            checked={continuousListening}
+            onChange={(e) => setContinuousListening(e.target.checked)}
+          />
+          <span className="switch-track" aria-hidden="true">
+            <span className="switch-thumb" />
+          </span>
+          <span>Keep listening between songs</span>
+        </label>
 
-          <div className="button-group">
-            <button onClick={handleStartListening} disabled={isListening}>
-              {isListening ? 'Listening…' : 'Start Listening'}
-            </button>
-            {isListening && (
-              <button onClick={handleStopListening} className="stop-button">
-                Stop
-              </button>
-            )}
-          </div>
+        <section className="history" aria-label="Recently caught tracks">
+          <p className="history-label">Recently caught</p>
+          {history.length === 0 ? (
+            <p className="history-empty">Songs you catch this session show up here.</p>
+          ) : (
+            <ul className="history-list">
+              {history.map((h) => (
+                <li className="history-row" key={`${h.key}-${h.at}`}>
+                  {h.art ? (
+                    <img className="history-thumb" src={h.art} alt="" aria-hidden="true" />
+                  ) : (
+                    <span className="history-thumb history-thumb--empty" aria-hidden="true">
+                      <OrbitDot state="idle" size="sm" />
+                    </span>
+                  )}
+                  <span className="history-meta">
+                    <span className="history-track">{h.title}</span>
+                    <span className="history-artist">{h.artist}</span>
+                  </span>
+                  <span className="history-time">{timeAgo(h.at, now)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
       </main>
     </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,11 +53,12 @@ function MainApp() {
 
   // Empty-state copy for the album canvas. When a track is already detected
   // but has no artwork, say so — don't tell the user to press Start again.
-  const emptyArtMessage = trackInfo
-    ? 'No artwork for this track'
-    : isListening
-      ? 'Listening for music…'
-      : 'Press Start to detect what’s playing';
+  let emptyArtMessage = 'Press Start to detect what’s playing';
+  if (trackInfo) {
+    emptyArtMessage = 'No artwork for this track';
+  } else if (isListening) {
+    emptyArtMessage = 'Listening for music…';
+  }
 
   const fetchAlbumArt = useCallback(async (artist, title) => {
     /**

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -51,6 +51,14 @@ function MainApp() {
 
   const orbitState = transientOrbitState || (isListening ? 'listening' : 'ready');
 
+  // Empty-state copy for the album canvas. When a track is already detected
+  // but has no artwork, say so — don't tell the user to press Start again.
+  const emptyArtMessage = trackInfo
+    ? 'No artwork for this track'
+    : isListening
+      ? 'Listening for music…'
+      : 'Press Start to detect what’s playing';
+
   const fetchAlbumArt = useCallback(async (artist, title) => {
     /**
      * Fetches album art from the backend for the given artist and title.
@@ -63,6 +71,9 @@ function MainApp() {
     }
 
     console.log(`🎨 Fetching album art for: ${artist} - ${title}`);
+    // Clear any artwork from the previous track so we never show stale art
+    // (or an alt text that no longer matches) while the new fetch is in flight.
+    setAlbumArt(null);
     setAlbumArtLoading(true);
 
     try {
@@ -255,7 +266,7 @@ function MainApp() {
         </div>
         <img src={user.picture} alt={user.name} className="user-avatar" />
         <span className="user-name">{user.name}</span>
-        <span className="lastfm-badge">🎵 Last.fm connected</span>
+        <span className="lastfm-badge">Last.fm connected</span>
         <SettingsDropdown />
         <button className="logout-btn" onClick={logout}>Sign out</button>
       </div>
@@ -280,7 +291,7 @@ function MainApp() {
             {!albumArtLoading && !albumArt && (
               <div className="album-art-placeholder album-art-empty">
                 <img src={recordMarkSrc} alt="" className="album-art-mark" aria-hidden="true" />
-                <span>{isListening ? 'Listening for music…' : 'Press Start — your detected track shows up here'}</span>
+                <span>{emptyArtMessage}</span>
               </div>
             )}
           </div>
@@ -316,11 +327,11 @@ function MainApp() {
 
           <div className="button-group">
             <button onClick={handleStartListening} disabled={isListening}>
-              {isListening ? '🎧 Listening…' : '🎵 Start Listening'}
+              {isListening ? 'Listening…' : 'Start Listening'}
             </button>
             {isListening && (
               <button onClick={handleStopListening} className="stop-button">
-                ⏹️ Stop
+                Stop
               </button>
             )}
           </div>

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -53,7 +53,6 @@ export default function LoginPage() {
                     </div>
 
                     <button className="login-lastfm-btn" onClick={connectLastFm}>
-                        <span className="lastfm-icon">🎵</span>
                         Connect Last.fm
                     </button>
 

--- a/frontend/src/components/SettingsDropdown.js
+++ b/frontend/src/components/SettingsDropdown.js
@@ -66,12 +66,16 @@ export default function SettingsDropdown() {
         title="Personalization settings"
         aria-label="Open personalization settings"
       >
-        ⚙️
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
       </button>
 
       {open && (
         <div className="settings-panel" role="dialog" aria-label="Personalization settings">
-          <p className="settings-heading">🎨 Theme</p>
+          <p className="settings-heading">Theme</p>
           <div className="settings-swatches">
             {Object.entries(THEMES).map(([key, theme]) => (
               <button
@@ -88,7 +92,7 @@ export default function SettingsDropdown() {
             ))}
           </div>
 
-          <p className="settings-heading">✏️ Font</p>
+          <p className="settings-heading">Font</p>
           <div className="settings-fonts">
             {Object.entries(FONTS).map(([key, font]) => (
               <button


### PR DESCRIPTION
## Summary

A full UI rework of the authenticated experience, in three stages (see commits):

1. **Cut redundant copy & consolidated empty states** — removed login-page marketing that survived into the app, and collapsed three different "nothing's happening yet" messages into one.
2. **Removed common "AI-generated UI" tells** — gradient text/buttons/background, glassmorphism blur, oversized headings, 24px+ radii, the one-sided accent bar on the track card, heavy glows, emoji-as-icons, and the default Inter font.
3. **Replaced the two-card dashboard with a single-focus "stage"** — the real fix. The old side-by-side panels left huge dead space because the app only ever has one action and one result to show.

## The new layout

Scrozam is a single-action tool (tap → it listens → shows the song → scrobbles), so the UI now centers on that:

- **The vinyl record is the primary control.** Tap it to listen; it spins and pulses a ring while listening (rotation tied to the listening state, per the brand guide), and fills with album art on detection.
- **Detected title + artist** sit directly under the record. Before listening, a single prompt ("Tap the record to listen").
- **Continuous mode** is now a compact inline toggle.
- **"Recently caught" session log** fills the space below with something useful — a live list of this session's detections with relative timestamps and thumbnails. Thumbnails reuse the now-playing art fetch (no extra requests). This leans into the brand's "living listening log" positioning.

## Notes
- No backend changes. Detection, scrobbling, polling, and the settings/personalization dropdown are untouched; the session log is client-side only.
- `npm run build` compiles cleanly (no lint warnings).
- Also addressed Copilot review feedback from earlier in the PR (stale album art / mismatched alt text, misleading empty-state copy) and a SonarCloud nested-ternary smell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)