### PR TITLE
fix(auth): validate Google credential type and size before verification

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -34,6 +34,13 @@ router.post('/google', async (req, res) => {
         return res.status(400).json({ error: 'Missing Google credential' });
     }
 
+    // Guard against non-string or oversized payloads before hitting Google.
+    // Valid Google ID tokens are compact JWTs (three dot-separated segments,
+    // well under 4KB); anything else is rejected without a network round-trip.
+    if (typeof credential !== 'string' || credential.length > 4096) {
+        return res.status(400).json({ error: 'Invalid Google credential' });
+    }
+
     try {
         // Verify the Google ID token via Google's tokeninfo endpoint
         const googleRes = await axios.get('https://oauth2.googleapis.com/tokeninfo', {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -37,7 +37,7 @@ router.post('/google', async (req, res) => {
     // Guard against non-string or oversized payloads before hitting Google.
     // Valid Google ID tokens are compact JWTs (three dot-separated segments,
     // well under 4KB); anything else is rejected without a network round-trip.
-    if (typeof credential !== 'string' || credential.length > 4096) {
+    if (typeof credential !== 'string' || Buffer.byteLength(credential, 'utf8') > 4096) {
         return res.status(400).json({ error: 'Invalid Google credential' });
     }
 


### PR DESCRIPTION
## Summary

`POST /auth/google` only checked that a `credential` was present, then forwarded it directly to Google's `tokeninfo` endpoint. A non-string or oversized payload (e.g. a multi-megabyte string) reached the outbound network call unchecked — a cheap input-fuzzing / resource-abuse vector.

This adds a type + length guard immediately after the existing presence check: reject anything that isn't a string or exceeds 4KB (valid Google ID tokens are compact JWTs, well under that). The guard matches the input-validation style already used in this file for theme/font preferences.

## Changes
- `backend/routes/auth.js`: reject non-string or `>4096`-char credentials with `400 { error: 'Invalid Google credential' }` before the Google round-trip.

## Testing
- Verified the guard logic against valid JWT-shaped tokens and abuse cases (non-string types, oversized strings, arrays) — all classified correctly.
- `node --check` passes on the modified file.
- The backend has no automated JS test framework configured, so validation was exercised via a standalone Node check rather than a suite run.

Found during a cross-repo code-quality review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mZVWx5wd5PdHs6n8UihBE

---
_Generated by [Claude Code](https://claude.ai/code/session_012mZVWx5wd5PdHs6n8UihBE)_