### PR TITLE
fix(album-art): block SSRF via redirect in image proxy

### DIFF
--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -219,6 +219,12 @@ router.get('/proxy', async (req, res) => {
         'User-Agent': 'Mozilla/5.0',
       },
       timeout: 10000,
+      // The host allowlist above only vets the initial URL. axios follows
+      // redirects by default, so an allowed host answering with a 3xx could
+      // send us to an internal/arbitrary address and defeat the allowlist
+      // (SSRF). Refuse to follow redirects; a 3xx then rejects into the
+      // catch below and is served as a 502.
+      maxRedirects: 0,
     });
 
     const imageHeaders = {


### PR DESCRIPTION
## Summary

The `/album-art/proxy` endpoint validates the requested image URL's host against an allowlist (`ALLOWED_IMAGE_HOSTS`), but `axios` follows HTTP redirects by default. An allowlisted host that responds with a `3xx` pointing at an internal or arbitrary address would be followed after the allowlist check had already passed — a classic **SSRF-via-redirect** bypass of the host allowlist.

This sets `maxRedirects: 0` on the proxy's `axios.get`, so redirects are never followed past the allowlist check. A `3xx` now rejects into the existing `catch` block and is served as a `502`, consistent with how other upstream failures are handled.

This is a defense-in-depth follow-up to the hardening tracked in #68 — the endpoint's posture is otherwise strong (host allowlist, protocol check, stream error handling, timeout).

## Changes
- `backend/routes/albumArt.js`: add `maxRedirects: 0` to the proxy request, with an explanatory comment.

## Testing
Verified locally against two throwaway HTTP servers using the same axios options as the proxy:
- **Redirect case:** an "allowed host" returning `302 → http://127.0.0.1/secret` is **not** followed — the internal target is never hit and the request rejects (→ `502`).
- **Happy path:** a direct `200` image response still streams through unchanged.

No dependency or behavioral changes for legitimate Last.fm CDN URLs, which return images directly (`200`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExV61xyXejuB8hNoSJmQFH)_