### PR TITLE
fix(backend): validate request input types on scrobble and album-art routes

### DIFF
--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -112,6 +112,11 @@ router.post('/', async (req, res) => {
     return res.status(400).json({ error: 'Artist and title are required' });
   }
 
+  if (typeof artist !== 'string' || typeof title !== 'string' ||
+      artist.length > 512 || title.length > 512) {
+    return res.status(400).json({ error: 'Artist and title must be strings of at most 512 characters' });
+  }
+
   if (!API_KEY) {
     return res.status(500).json({ error: 'Last.fm API key not configured' });
   }

--- a/backend/routes/detectSong.js
+++ b/backend/routes/detectSong.js
@@ -107,9 +107,6 @@ router.post('/', upload.single('sample'), async (req, res) => {
       res.status(500).send('Song detection failed');
     }
   } catch (error) {
-    if (error.code === 'LIMIT_FILE_SIZE') {
-      return res.status(413).send('Audio file is too large');
-    }
     console.error('Error detecting song:', error.response?.status || error.message);
     res.status(500).send('Error detecting song');
   }

--- a/backend/routes/scrobbleSong.js
+++ b/backend/routes/scrobbleSong.js
@@ -50,6 +50,15 @@ router.post('/', async (req, res) => {
         return res.status(400).send('Artist and title are required');
     }
 
+    if (typeof artist !== 'string' || typeof title !== 'string' ||
+        artist.length > 512 || title.length > 512) {
+        return res.status(400).send('Artist and title must be strings of at most 512 characters');
+    }
+
+    if (typeof chosenByUser !== 'string' || !['0', '1'].includes(chosenByUser)) {
+        return res.status(400).send('chosenByUser must be "0" or "1"');
+    }
+
     if (!API_KEY || !SHARED_SECRET) {
         return res.status(500).send('Last.fm API credentials are not configured');
     }


### PR DESCRIPTION
## Summary

Small backend hardening pass from a cross-repo review. Two POST routes only truthy-checked their `artist`/`title` inputs, so a JSON body sending those fields as objects or arrays flowed unchecked into `URLSearchParams` and the signed Last.fm request (and into `stripTitle(...).replace` in the album-art route, which then threw a generic 500).

## Changes

- **`backend/routes/scrobbleSong.js`** — reject `artist`/`title` that aren't strings or exceed 512 chars, and restrict `chosenByUser` to `'0'`/`'1'`. Mirrors the existing `typeof`/length validation pattern in `auth.js`.
- **`backend/routes/albumArt.js`** — same string/length guard on `artist`/`title` before they reach `stripTitle` and the Last.fm calls.
- **`backend/routes/detectSong.js`** — remove an unreachable `LIMIT_FILE_SIZE` branch. Multer emits that error from the `upload.single` middleware, which the app-level error handler (`app.js:168`) already converts to a 413 before the route's `try/catch` runs, so the branch was dead code.

## Testing

- `node --check` passes on all four touched files.
- Mounted both routers in a throwaway Express app and fired requests: object/array `artist`/`title` and an out-of-range `chosenByUser` all return **400**; valid string inputs pass validation and proceed as before.

## Not included (recommendations only)

- `.github/workflows/dependency-review.yml` has `fail-on-severity` commented out, so the dependency gate never blocks. Enabling it changes PR-gating policy, so leaving that call to you.
- Known items #68 (deprecated `csurf` / in-memory session store) and #30 (fetch streamlining) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9

---
_Generated by [Claude Code](https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9)_