### PR TITLE
fix(auth): verify Google ID token audience to prevent token substitution

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,12 @@ ACR_SHARED=your_acrcloud_shared_secret
 LAST_API_KEY=your_lastfm_api_key
 LAST_SHARED_SECRET=your_lastfm_shared_secret
 
+# ── Google SSO ────────────────────────────────────────────────────────────────
+# OAuth 2.0 Client ID from the Google Cloud console. Used to verify that ID
+# tokens presented to /auth/google were actually issued for this app (audience
+# check). When unset, audience verification is skipped with a startup warning.
+GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
+
 # ── Session ───────────────────────────────────────────────────────────────────
 # Generate a strong random string for production: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SESSION_SECRET=change-me-in-production

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -62,7 +62,7 @@ router.post('/google', async (req, res) => {
         // anything whose `aud` does not match our own client ID.
         if (GOOGLE_CLIENT_ID) {
             if (aud !== GOOGLE_CLIENT_ID) {
-                console.warn(`⚠️  Rejected Google token with mismatched aud: ${aud}`);
+                console.warn('⚠️  Rejected Google sign-in: token audience did not match GOOGLE_CLIENT_ID.');
                 return res.status(401).json({ error: 'Invalid Google token' });
             }
         } else {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -21,6 +21,11 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000';
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
+// Warn once at startup (not per request) when audience verification is disabled.
+if (!GOOGLE_CLIENT_ID) {
+    console.warn('⚠️  GOOGLE_CLIENT_ID is not set — Google ID token audience verification is disabled. Set it to harden Google SSO.');
+}
+
 // ─── Google SSO ───────────────────────────────────────────────────────────────
 
 /**
@@ -56,17 +61,13 @@ router.post('/google', async (req, res) => {
         }
 
         // Google's tokeninfo endpoint validates the token's signature and expiry,
-        // but not that it was issued for *this* app. Without an audience check, a
-        // valid ID token minted for any other Google OAuth client could be replayed
-        // here to mint a Scrozam session as that user (audience confusion). Reject
-        // anything whose `aud` does not match our own client ID.
-        if (GOOGLE_CLIENT_ID) {
-            if (aud !== GOOGLE_CLIENT_ID) {
-                console.warn('⚠️  Rejected Google sign-in: token audience did not match GOOGLE_CLIENT_ID.');
-                return res.status(401).json({ error: 'Invalid Google token' });
-            }
-        } else {
-            console.warn('⚠️  GOOGLE_CLIENT_ID is not set — skipping audience verification. Set it to harden Google SSO.');
+        // but not that it was issued for *this* app. Reject any token whose `aud`
+        // does not match our own client ID (audience confusion / token substitution).
+        // When GOOGLE_CLIENT_ID is unset, verification is skipped — see the startup
+        // warning above.
+        if (GOOGLE_CLIENT_ID && aud !== GOOGLE_CLIENT_ID) {
+            console.warn('⚠️  Rejected Google sign-in: token audience did not match GOOGLE_CLIENT_ID.');
+            return res.status(401).json({ error: 'Invalid Google token' });
         }
 
         const user = upsertUser(sub, { email, name, picture });
@@ -188,7 +189,6 @@ router.get('/lastfm/callback', async (req, res) => {
 });
 
 // ─── Personalization ──────────────────────────────────────────────────────────
-
 const VALID_THEMES = ['midnight', 'crimson', 'ocean', 'forest', 'sunset', 'aurora'];
 const VALID_FONTS  = ['segoe', 'inter', 'mono', 'georgia', 'playfair'];
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -18,6 +18,7 @@ const LAST_API_KEY = process.env.LAST_API_KEY;
 const LAST_SHARED_SECRET = process.env.LAST_SHARED_SECRET;
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3001';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000';
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 // ─── Google SSO ───────────────────────────────────────────────────────────────
@@ -48,10 +49,24 @@ router.post('/google', async (req, res) => {
             timeout: 10000,
         });
 
-        const { sub, email, name, picture } = googleRes.data;
+        const { aud, sub, email, name, picture } = googleRes.data;
 
         if (!sub) {
             return res.status(401).json({ error: 'Invalid Google token' });
+        }
+
+        // Google's tokeninfo endpoint validates the token's signature and expiry,
+        // but not that it was issued for *this* app. Without an audience check, a
+        // valid ID token minted for any other Google OAuth client could be replayed
+        // here to mint a Scrozam session as that user (audience confusion). Reject
+        // anything whose `aud` does not match our own client ID.
+        if (GOOGLE_CLIENT_ID) {
+            if (aud !== GOOGLE_CLIENT_ID) {
+                console.warn(`⚠️  Rejected Google token with mismatched aud: ${aud}`);
+                return res.status(401).json({ error: 'Invalid Google token' });
+            }
+        } else {
+            console.warn('⚠️  GOOGLE_CLIENT_ID is not set — skipping audience verification. Set it to harden Google SSO.');
         }
 
         const user = upsertUser(sub, { email, name, picture });


### PR DESCRIPTION
## Problem

`POST /auth/google` verifies a Google ID token by calling Google's `tokeninfo` endpoint. That endpoint validates the token's **signature and expiry**, but it does **not** check that the token was minted for *this* application. The handler then trusts `sub`/`email` and creates a session:

```js
const { sub, email, name, picture } = googleRes.data;
if (!sub) { return res.status(401)... }
const user = upsertUser(sub, { email, name, picture });
req.session.userId = sub;
```

Because there is no `aud` (audience) check, a valid Google ID token issued to **any other** Google OAuth client could be replayed against this endpoint to mint a Scrozam session as that Google user — a classic audience-confusion / token-substitution weakness. Google's own guidance lists verifying `aud` as mandatory.

## Fix

- Destructure `aud` from the tokeninfo response and reject the request when it does not match `GOOGLE_CLIENT_ID`, before any session is created.
- The check **enforces when `GOOGLE_CLIENT_ID` is configured** and logs a warning when it is not, so existing deployments keep working until the value is set (fail-safe rollout rather than an immediate hard break).
- Document `GOOGLE_CLIENT_ID` in `backend/.env.example`.

## Notes

- Small, self-contained change; no new dependencies.
- For full hardening, set `GOOGLE_CLIENT_ID` in the backend environment — the warning log makes it obvious when audience verification is inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8hL4gquqrhs1ZqNSJsmSt

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8hL4gquqrhs1ZqNSJsmSt)_