### PR TITLE
fix(backend): add request timeouts to Last.fm API calls

### DIFF
--- a/backend/routes/albumArt.js
+++ b/backend/routes/albumArt.js
@@ -47,7 +47,8 @@ const fetchAlbumInfo = async (artist, albumName) => {
         artist: artist,
         album: albumName,
         format: 'json'
-      }
+      },
+      timeout: 10000
     });
 
     if (response.data.album?.image) {
@@ -73,7 +74,8 @@ const fetchArtistInfo = async (artist) => {
         api_key: API_KEY,
         artist: artist,
         format: 'json'
-      }
+      },
+      timeout: 10000
     });
 
     if (response.data.artist?.image) {
@@ -128,7 +130,8 @@ router.post('/', async (req, res) => {
     const tryTrackInfo = async (trackTitle) => {
       try {
         const trackResponse = await axios.get('https://ws.audioscrobbler.com/2.0/', {
-          params: { method: 'track.getInfo', api_key: API_KEY, artist, track: trackTitle, format: 'json' }
+          params: { method: 'track.getInfo', api_key: API_KEY, artist, track: trackTitle, format: 'json' },
+          timeout: 10000
         });
         const track = trackResponse.data.track;
         if (!track) return null;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -169,6 +169,7 @@ router.get('/lastfm/callback', async (req, res) => {
         const response = await axios.get('https://ws.audioscrobbler.com/2.0/', {
             params: { ...params, api_sig, format: 'json' },
             family: 4,
+            timeout: 10000,
         });
 
         const sessionKey = response.data?.session?.key;


### PR DESCRIPTION
## What & why

Four outbound `axios.get` calls to the Last.fm API were issued with **no timeout**, so if Last.fm stalls or half-opens a connection, the Express request hangs indefinitely with no way to recover. In `albumArt.js` this is compounded by the retry chain (`tryTrackInfo` → stripped-title retry → artist fallback), where multiple hung calls can stack on a single request.

These stood out as clear oversights because the author already sets `timeout: 10000` on the sibling calls in the very same files — the `/album-art/proxy` image fetch and the Google `tokeninfo` verification in `auth.js`.

## Change

Add `timeout: 10000` (10s) to the four Last.fm calls, matching the existing convention:

- `backend/routes/albumArt.js` — `fetchAlbumInfo` (`album.getInfo`)
- `backend/routes/albumArt.js` — `fetchArtistInfo` (`artist.getInfo`)
- `backend/routes/albumArt.js` — `tryTrackInfo` (`track.getInfo`)
- `backend/routes/auth.js` — `/auth/lastfm/callback` session exchange (`auth.getSession`, alongside the existing `family: 4`)

No behavioral change on the success path. A genuinely hung request now rejects with a timeout error, which flows into the existing `catch` blocks (mapped to a `500`/`404` or an error redirect) instead of blocking the request.

## Testing

- `node --check backend/routes/albumArt.js` passes.
- `node --check backend/routes/auth.js` passes.
- The repo has no automated test suite (`npm test` is the placeholder `no test specified`).

---
_Generated by [Claude Code](https://claude.ai/code/session_0154vS9xGVYkJfLuAQ37gysQ)_