### PR TITLE
fix(song-store): key detected songs by user to prevent cross-user leak

### DIFF
--- a/backend/routes/detectSong.js
+++ b/backend/routes/detectSong.js
@@ -95,8 +95,8 @@ router.post('/', upload.single('sample'), async (req, res) => {
       // Log what’s being sent back to the frontend
       console.log(`Detected Song -> Title: ${title}, Artist: ${artist}`);
     
-      // Store in songStore (no HTTP round-trip needed)
-      setDetectedSong({ title, artist });
+      // Store in songStore, keyed by user so concurrent users don't collide
+      setDetectedSong(req.session.userId, { title, artist });
       console.log(`Stored detected song: ${title} by ${artist}`);
       res.json({ title, artist });
     } else if (response.data.status.code === 1001) {

--- a/backend/routes/detectedSong.js
+++ b/backend/routes/detectedSong.js
@@ -13,7 +13,7 @@ router.get('/', (req, res) => {
      * GET /detected-song
      * Returns the most recently detected song and clears it, or null.
      */
-    const song = popDetectedSong();
+    const song = popDetectedSong(req.session.userId);
     if (song) {
         console.log(`🎧 Sending detected song to frontend: ${song.title} - ${song.artist}`);
     } else {

--- a/backend/songStore.js
+++ b/backend/songStore.js
@@ -7,11 +7,31 @@
  * concurrent users never receive one another's results. Both routes that
  * use this store run behind requireAuth, so a userId is always available.
  *
+ * A detected song is only relevant for the brief window between detection
+ * and the frontend's next poll, so each entry carries a short TTL. Expired
+ * entries are pruned on every write, which keeps the map from growing
+ * unbounded when a user detects a song but never polls (e.g. disconnects).
+ *
  * Written by DJ Leamen 2024-2026
  */
 
-// Map<userId, { title: string, artist: string }>
+// Map<userId, { song: { title, artist }, expiresAt: number }>
 const detectedSongs = new Map();
+
+// A pending detection is short-lived; the frontend polls shortly after.
+const ENTRY_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Removes any entries that have passed their TTL.
+ * @param {number} now - Current timestamp in ms
+ */
+function pruneExpired(now) {
+    for (const [userId, entry] of detectedSongs) {
+        if (entry.expiresAt <= now) {
+            detectedSongs.delete(userId);
+        }
+    }
+}
 
 /**
  * Stores the most recently detected song for a user.
@@ -20,20 +40,24 @@ const detectedSongs = new Map();
  */
 function setDetectedSong(userId, song) {
     if (!userId) return;
-    detectedSongs.set(userId, song);
+    const now = Date.now();
+    pruneExpired(now);
+    detectedSongs.set(userId, { song, expiresAt: now + ENTRY_TTL_MS });
     console.log('📀 Stored detected song in songStore:', song);
 }
 
 /**
  * Returns the most recently detected song for a user and clears it.
+ * Entries past their TTL are treated as absent.
  * @param {string} userId - Authenticated user's id (Google sub)
  * @returns {{ title: string, artist: string } | null}
  */
 function popDetectedSong(userId) {
     if (!userId) return null;
-    const song = detectedSongs.get(userId) ?? null;
+    const entry = detectedSongs.get(userId);
     detectedSongs.delete(userId);
-    return song;
+    if (!entry || entry.expiresAt <= Date.now()) return null;
+    return entry.song;
 }
 
 module.exports = { setDetectedSong, popDetectedSong };

--- a/backend/songStore.js
+++ b/backend/songStore.js
@@ -2,28 +2,37 @@
  * In-memory song store for Scrozam.
  * Replaces the HTTP POST to /detected-song from within detectSong.js
  * to avoid internal circular HTTP calls.
- * 
+ *
+ * Detected songs are keyed by the authenticated user's id so that
+ * concurrent users never receive one another's results. Both routes that
+ * use this store run behind requireAuth, so a userId is always available.
+ *
  * Written by DJ Leamen 2024-2026
  */
 
-let detectedSong = null;
+// Map<userId, { title: string, artist: string }>
+const detectedSongs = new Map();
 
 /**
- * Stores the most recently detected song.
+ * Stores the most recently detected song for a user.
+ * @param {string} userId - Authenticated user's id (Google sub)
  * @param {{ title: string, artist: string }} song
  */
-function setDetectedSong(song) {
-    detectedSong = song;
+function setDetectedSong(userId, song) {
+    if (!userId) return;
+    detectedSongs.set(userId, song);
     console.log('📀 Stored detected song in songStore:', song);
 }
 
 /**
- * Returns the most recently detected song and clears it.
+ * Returns the most recently detected song for a user and clears it.
+ * @param {string} userId - Authenticated user's id (Google sub)
  * @returns {{ title: string, artist: string } | null}
  */
-function popDetectedSong() {
-    const song = detectedSong;
-    detectedSong = null;
+function popDetectedSong(userId) {
+    if (!userId) return null;
+    const song = detectedSongs.get(userId) ?? null;
+    detectedSongs.delete(userId);
     return song;
 }
 


### PR DESCRIPTION
## Problem

`backend/songStore.js` held the most recently detected song in a single module-level global (`let detectedSong = null`). But the app is multi-user (Google SSO + per-user `userStore`), and the two endpoints that use this store both run behind `requireAuth`:

- `POST /detect-song` → `setDetectedSong(...)` (writer)
- `GET /detected-song` → `popDetectedSong()` (poller)

When two authenticated users are active at once, one user's poll could pop the *other* user's detected song. That's a **cross-user data leak** and a correctness race — the result depends on interleaving rather than on who made the request.

## Fix

Key the store by the authenticated user's id (`req.session.userId`):

- `songStore.js` now backs the store with a `Map<userId, song>`; `setDetectedSong(userId, song)` and `popDetectedSong(userId)` operate on that user's slot only. The map is self-cleaning — `pop` deletes the entry after reading, so it only ever holds entries for users with an unpolled detection.
- `routes/detectSong.js` passes `req.session.userId` when storing.
- `routes/detectedSong.js` passes `req.session.userId` when popping.
- Missing/undefined ids are handled as safe no-ops (defensive; both routes are already auth-gated so an id is always present).

## Testing

No JS test framework is configured in the backend, so verification was done via `node --check` on all three modules plus a smoke test asserting:

- Two users store distinct songs and each pops only their own (no cross-user leak).
- A second pop returns `null` (pop clears the slot).
- Unknown-user and missing-id pops return `null`; a missing-id set is a no-op and does not throw.

All assertions pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_019S7Ypm4krn5T1XwQs4Tz7B)_