### PR TITLE
test(song-store): cover per-user isolation and TTL expiry

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/backend/songStore.js
+++ b/backend/songStore.js
@@ -60,4 +60,14 @@ function popDetectedSong(userId) {
     return entry.song;
 }
 
-module.exports = { setDetectedSong, popDetectedSong };
+/**
+ * Returns the number of entries currently held, including any that have
+ * expired but not yet been pruned. Exposed for tests and introspection so
+ * the map's bounded-memory guarantee can be asserted directly.
+ * @returns {number}
+ */
+function entryCount() {
+    return detectedSongs.size;
+}
+
+module.exports = { setDetectedSong, popDetectedSong, entryCount };

--- a/backend/songStore.test.js
+++ b/backend/songStore.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for the in-memory song store.
+ *
+ * Uses Node's built-in test runner (node:test) so the backend gains
+ * coverage without pulling in a test framework. The store keys detections
+ * by userId and expires them on a TTL, so the tests focus on cross-user
+ * isolation and expiry — the two behaviours that keep detections private
+ * and the map bounded.
+ *
+ * Written by DJ Leamen 2024-2026
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Silence the store's console.log so test output stays readable.
+const originalLog = console.log;
+console.log = () => {};
+
+const { setDetectedSong, popDetectedSong } = require('./songStore');
+
+const ENTRY_TTL_MS = 5 * 60 * 1000;
+const SONG = { title: 'Bohemian Rhapsody', artist: 'Queen' };
+
+// Pin Date.now so TTL behaviour is deterministic; each test restores it.
+function withClock(startMs, fn) {
+    const realNow = Date.now;
+    let current = startMs;
+    Date.now = () => current;
+    const advance = (ms) => { current += ms; };
+    try {
+        fn(advance);
+    } finally {
+        Date.now = realNow;
+    }
+}
+
+test('stores and pops a song for a user', () => {
+    withClock(1000, () => {
+        setDetectedSong('user-a', SONG);
+        assert.deepStrictEqual(popDetectedSong('user-a'), SONG);
+    });
+});
+
+test('pop clears the entry so a second pop returns null', () => {
+    withClock(1000, () => {
+        setDetectedSong('user-a', SONG);
+        popDetectedSong('user-a');
+        assert.strictEqual(popDetectedSong('user-a'), null);
+    });
+});
+
+test('one user never receives another user\'s song', () => {
+    withClock(1000, () => {
+        setDetectedSong('user-a', SONG);
+        assert.strictEqual(popDetectedSong('user-b'), null);
+        // user-a's entry is untouched by user-b's poll.
+        assert.deepStrictEqual(popDetectedSong('user-a'), SONG);
+    });
+});
+
+test('an entry past its TTL is treated as absent', () => {
+    withClock(1000, (advance) => {
+        setDetectedSong('user-a', SONG);
+        advance(ENTRY_TTL_MS + 1);
+        assert.strictEqual(popDetectedSong('user-a'), null);
+    });
+});
+
+test('an entry within its TTL is still returned', () => {
+    withClock(1000, (advance) => {
+        setDetectedSong('user-a', SONG);
+        advance(ENTRY_TTL_MS - 1);
+        assert.deepStrictEqual(popDetectedSong('user-a'), SONG);
+    });
+});
+
+test('a later write prunes another user\'s expired entry', () => {
+    withClock(1000, (advance) => {
+        setDetectedSong('user-a', SONG);
+        advance(ENTRY_TTL_MS + 1);
+        // user-b writing after user-a expired should prune user-a.
+        setDetectedSong('user-b', { title: 'Africa', artist: 'Toto' });
+        assert.strictEqual(popDetectedSong('user-a'), null);
+    });
+});
+
+test('a falsy userId is ignored on write and read', () => {
+    withClock(1000, () => {
+        setDetectedSong('', SONG);
+        assert.strictEqual(popDetectedSong(''), null);
+        assert.strictEqual(popDetectedSong(undefined), null);
+    });
+});
+
+test.after(() => {
+    console.log = originalLog;
+});

--- a/backend/songStore.test.js
+++ b/backend/songStore.test.js
@@ -17,7 +17,7 @@ const assert = require('node:assert');
 const originalLog = console.log;
 console.log = () => {};
 
-const { setDetectedSong, popDetectedSong } = require('./songStore');
+const { setDetectedSong, popDetectedSong, entryCount } = require('./songStore');
 
 const ENTRY_TTL_MS = 5 * 60 * 1000;
 const SONG = { title: 'Bohemian Rhapsody', artist: 'Queen' };
@@ -79,9 +79,17 @@ test('a later write prunes another user\'s expired entry', () => {
     withClock(1000, (advance) => {
         setDetectedSong('user-a', SONG);
         advance(ENTRY_TTL_MS + 1);
-        // user-b writing after user-a expired should prune user-a.
+        // user-a is expired but still physically present until a write prunes it.
+        assert.strictEqual(entryCount(), 1);
+        // user-b writing prunes the expired user-a entry rather than growing the
+        // map, so the count stays at 1 instead of climbing to 2. Asserting the
+        // count (not just a null pop) is what actually exercises prune-on-write:
+        // a null pop alone would pass even if pruning never ran.
         setDetectedSong('user-b', { title: 'Africa', artist: 'Toto' });
+        assert.strictEqual(entryCount(), 1);
+        // user-a is genuinely gone, not merely treated as absent on read.
         assert.strictEqual(popDetectedSong('user-a'), null);
+        popDetectedSong('user-b');
     });
 });
 


### PR DESCRIPTION
## What changed

The backend previously had **no tests** — its `test` script just printed an error and exited 1. Meanwhile `backend/songStore.js` was recently hardened with two security-sensitive behaviours that had no coverage:

- **Per-user keying** (`bdb46b3`) — detections are keyed by `userId` so concurrent users never receive one another's results.
- **TTL expiry** (`c6b2718`) — entries expire after 5 min and are pruned on every write, keeping the in-memory map bounded.

This PR adds unit tests for that logic using Node's built-in test runner (`node:test`), so **no new dependencies** are introduced, and points the backend `test` script at `node --test`.

## Coverage

- Store round-trip (set → pop returns the song)
- Pop clears the entry (second pop returns `null`)
- **Cross-user isolation** — user B's poll never returns user A's song, and doesn't consume it
- **TTL expiry** — an entry past its TTL is treated as absent
- An entry still within its TTL is returned
- A later write prunes another user's expired entry (bounded memory)
- Falsy `userId` is ignored on write and read

## Testing

```
cd backend && npm test
# 7 tests, 7 pass
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4a5ACjnEymMoaH8QXNQMf)_